### PR TITLE
fix: add Docker Hub registry credentials to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,64 @@
 ---
 version: 2
+registries:
+  dockerhub:
+    type: docker-registry
+    url: https://registry.hub.docker.com
+    username: ${{secrets.DOCKERHUB_USERNAME}}
+    password: ${{secrets.DOCKERHUB_PASSWORD}}
 updates:
   - package-ecosystem: "docker"
     directory: "/services/briefing"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/awesome_annual_security_reports"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/cvelist"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/enrich_text"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/miniflux"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/readwise"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/zotero"
+    registries:
+      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Summary

- Docker Hub now requires authentication even for public images, causing Dependabot to get 401 UNAUTHORIZED errors when checking `python:3.12-slim` updates
- Added a `dockerhub` registry entry to `dependabot.yml` using `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` secrets
- Referenced the registry in all 7 docker package-ecosystem entries

## Test plan

- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` secrets to the repository (Settings → Secrets and variables → Dependabot)
- [ ] Merge this PR and trigger a Dependabot run to verify no more 401 errors

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)