### PR TITLE
fix: remove unused Docker Hub credentials from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,64 +1,44 @@
 ---
 version: 2
-registries:
-  dockerhub:
-    type: docker-registry
-    url: https://registry.hub.docker.com
-    username: ${{secrets.DOCKERHUB_USERNAME}}
-    password: ${{secrets.DOCKERHUB_PASSWORD}}
 updates:
   - package-ecosystem: "docker"
     directory: "/services/briefing"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/awesome_annual_security_reports"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/cvelist"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/enrich_text"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/miniflux"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/readwise"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
     directory: "/services/connectors/zotero"
-    registries:
-      - dockerhub
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Summary
- Removes the `registries` block and all per-entry `registries` references from `dependabot.yml`
- All Dockerfiles use public `python:3.12-slim` images — no authentication needed
- Fixes Dependabot docker jobs failing with `422: Secret Not Found: DOCKERHUB_USERNAME`

## Test plan
- [ ] Verify next scheduled Dependabot docker run succeeds without credential errors
- [ ] Confirm existing uv and github-actions Dependabot runs are unaffected

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)